### PR TITLE
修复女仆使用铁魔法的部分法术时，会对主人施放不在法术白名单里的法术的问题

### DIFF
--- a/src/main/java/com/github/yimeng261/maidspell/mixin/iss/UtilsMixin.java
+++ b/src/main/java/com/github/yimeng261/maidspell/mixin/iss/UtilsMixin.java
@@ -1,0 +1,40 @@
+package com.github.yimeng261.maidspell.mixin.iss;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import io.redspace.ironsspellbooks.api.magic.MagicData;
+import io.redspace.ironsspellbooks.api.spells.AbstractSpell;
+import io.redspace.ironsspellbooks.api.util.Utils;
+import io.redspace.ironsspellbooks.capabilities.magic.TargetEntityCastData;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.Level;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.function.Predicate;
+
+/**
+ * 使女仆施法时设置了目标实体后，不再被视线射线检测覆盖目标
+ */
+@Mixin(value = Utils.class, remap = false)
+public class UtilsMixin {
+    @Inject(method = "preCastTargetHelper(Lnet/minecraft/world/level/Level;Lnet/minecraft/world/entity/LivingEntity;Lio/redspace/ironsspellbooks/api/magic/MagicData;Lio/redspace/ironsspellbooks/api/spells/AbstractSpell;IFZLjava/util/function/Predicate;)Z", at = @At("HEAD"), cancellable = true)
+    private static void beforePreCastTargetHelper(Level level, LivingEntity caster, MagicData playerMagicData, AbstractSpell spell, int range, float aimAssist, boolean sendFailureMessage, Predicate<LivingEntity> filter, CallbackInfoReturnable<Boolean> cir) {
+        // 只处理女仆的目标实体
+        if (!(caster instanceof EntityMaid))
+            return;
+        // 如果没有指定目标实体则还是使用默认的射线检测
+        if (!(playerMagicData.getAdditionalCastData() instanceof TargetEntityCastData targetEntityCastData))
+            return;
+        
+        LivingEntity targetEntity = targetEntityCastData.getTarget((ServerLevel) caster.level());
+        // 如果目标实体是玩家则发送提示
+        if (targetEntity instanceof ServerPlayer targetPlayerEntity) {
+            Utils.sendTargetedNotification(targetPlayerEntity, caster, spell);
+        }
+        cir.setReturnValue(true);
+    }
+}

--- a/src/main/java/com/github/yimeng261/maidspell/spell/providers/IronsSpellbooksProvider.java
+++ b/src/main/java/com/github/yimeng261/maidspell/spell/providers/IronsSpellbooksProvider.java
@@ -18,6 +18,7 @@ import io.redspace.ironsspellbooks.api.spells.CastSource;
 import io.redspace.ironsspellbooks.api.spells.CastType;
 import io.redspace.ironsspellbooks.api.spells.ISpellContainer;
 import io.redspace.ironsspellbooks.api.util.Utils;
+import io.redspace.ironsspellbooks.capabilities.magic.TargetEntityCastData;
 import io.redspace.ironsspellbooks.entity.spells.target_area.TargetedAreaEntity;
 import io.redspace.ironsspellbooks.api.item.weapons.MagicSwordItem;
 import io.redspace.ironsspellbooks.spells.TargetAreaCastData;
@@ -487,6 +488,12 @@ public class IronsSpellbooksProvider extends ISpellBookProvider<MaidIronsSpellDa
                     maid.level(), targetPosition, radius, Utils.packRGB(spell.getTargetingColor()));
                 magicData.setAdditionalCastData(new TargetAreaCastData(targetPosition, area));
             }
+        }
+        // 其它法术直接设置目标实体，即使该法术不需要目标实体
+        // 如果不设置目标实体，则施放需要目标实体的法术时会基于女仆视线进行射线检测，可能会锁定到非目标实体（#23）
+        // 另见 UtilsMixin
+        else {
+            magicData.setAdditionalCastData(new TargetEntityCastData(target));
         }
     }
     

--- a/src/main/resources/maidspell.mixins.json
+++ b/src/main/resources/maidspell.mixins.json
@@ -22,7 +22,8 @@
     "OpenMaidGuiMessageMixin",
     "SynchedEntityDataMixin",
     "WandUtilMixin",
-    "iss.SyncedSpellDataMixin"
+    "iss.SyncedSpellDataMixin",
+    "iss.UtilsMixin"
   ],
   "client": [
     "iss.ClientMagicDataMixin",


### PR DESCRIPTION
## 描述
令女仆施放法术时默认显式指定目标实体，并阻止铁魔法通过视线射线检测覆盖设定的目标实体。

## 参考
Fixes #23
