### PR TITLE
添加FTBTeams支持

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,6 +90,13 @@ repositories {
             includeGroup "com.tterrag.registrate"
         }
     }
+//    maven {
+//        name = "TterragRegistrate"
+//        url = "https://maven.tterrag.com/"
+//        content {
+//            includeGroup "com.tterrag.registrate"
+//        }
+//    }
     maven {
         name = "Modrinth"
         url = "https://api.modrinth.com/maven"

--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,12 @@ repositories {
             includeGroup "curse.maven"
         }
     }
-    maven { // Registrate
-        url "https://maven.tterrag.com/"
+    maven {
+        name = "ModMavenRegistrate"
+        url = "https://modmaven.dev"
+        content {
+            includeGroup "com.tterrag.registrate"
+        }
     }
     maven {
         name = "Modrinth"
@@ -130,6 +134,10 @@ dependencies {
     runtimeOnly fg.deobf("maven.modrinth:playeranimator:1.0.2-rc1+1.20-forge")
     //implementation fg.deobf("maven.modrinth:irons-spells-n-spellbooks:1.20.1-3.4.0.9-forge")
     implementation fg.deobf("curse.maven:irons-spells-n-spellbooks-855414:7402504")
+
+    implementation fg.deobf("curse.maven:ftb-teams-forge-404468:7499810")
+    runtimeOnly fg.deobf("curse.maven:ftb-library-forge-404465:8226927")
+    runtimeOnly fg.deobf("curse.maven:architectury-api-419699:5137938")
 
     implementation fg.deobf("maven.modrinth:ars-nouveau:4.12.6-forge,1.20.1")
 

--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ dependencies {
 
     implementation fg.deobf("curse.maven:ftb-teams-forge-404468:7499810")
     runtimeOnly fg.deobf("curse.maven:ftb-library-forge-404465:8226927")
-    runtimeOnly fg.deobf("curse.maven:architectury-api-419699:5137938")
+    implementation fg.deobf("curse.maven:architectury-api-419699:5137938")
 
     implementation fg.deobf("maven.modrinth:ars-nouveau:4.12.6-forge,1.20.1")
 

--- a/src/main/java/com/github/yimeng261/maidspell/MaidSpellMod.java
+++ b/src/main/java/com/github/yimeng261/maidspell/MaidSpellMod.java
@@ -2,6 +2,7 @@ package com.github.yimeng261.maidspell;
 
 import com.github.yimeng261.maidspell.block.MaidSpellBlocks;
 import com.github.yimeng261.maidspell.block.entity.MaidSpellBlockEntities;
+import com.github.yimeng261.maidspell.compat.ftbteams.FTBTeamsCompat;
 import com.github.yimeng261.maidspell.compat.irons_spellbooks.IronsSpellbooksCompat;
 import com.github.yimeng261.maidspell.crafting.OptionalModIngredientSerializer;
 import com.github.yimeng261.maidspell.event.FoxLeafOwnerWaterWalking;
@@ -64,6 +65,7 @@ public class MaidSpellMod {
         MaidSpellContainers.register(modBus);
         MaidSpellSounds.SOUNDS.register(modBus);
         MaidSpellEntities.register(modBus);
+        FTBTeamsCompat.init();
         IronsSpellbooksCompat.init(modBus);
         // 注册自定义结构
         MaidSpellStructures.STRUCTURE_TYPES.register(modBus);

--- a/src/main/java/com/github/yimeng261/maidspell/compat/MaidSpellAllyResolver.java
+++ b/src/main/java/com/github/yimeng261/maidspell/compat/MaidSpellAllyResolver.java
@@ -62,7 +62,7 @@ public final class MaidSpellAllyResolver {
                 return true;
             }
         }
-        return FTBTeamsCompat.areFriendly(firstOwners, secondOwners);
+        return FTBTeamsCompat.areFriendly(first, firstOwners, secondOwners);
     }
 
     private static boolean hasExplicitTeamAlliance(Entity first, Entity second) {
@@ -75,9 +75,9 @@ public final class MaidSpellAllyResolver {
     }
 
     public static boolean isFriendlyDamage(LivingEntity target, @Nullable Entity causing, @Nullable Entity direct) {
-        return areFriendly(target, causing)
-                || areFriendly(target, direct)
-                || resolveResponsibleEntity(direct).map(owner -> areFriendly(target, owner)).orElse(false);
+        return areFriendly(causing, target)
+                || areFriendly(direct, target)
+                || resolveResponsibleEntity(direct).map(owner -> areFriendly(owner, target)).orElse(false);
     }
 
     public static Optional<Entity> resolveResponsibleEntity(@Nullable Entity entity) {
@@ -100,6 +100,28 @@ public final class MaidSpellAllyResolver {
         Set<UUID> ids = new HashSet<>();
         collectAffinityIds(entity, ids, new HashSet<>(), 0);
         return ids;
+    }
+
+    public static AffinityType getAffinityType(@Nullable Entity entity) {
+        if (entity == null) {
+            return AffinityType.NONE;
+        }
+        Entity current = entity;
+        boolean playerFound = false;
+        for (int depth = 0; depth < OWNER_TRACE_LIMIT && current != null; depth++) {
+            if (current instanceof EntityMaid) {
+                return AffinityType.MAID;
+            }
+            if (current instanceof Player) {
+                playerFound = true;
+            }
+            Entity owner = getDirectOwner(current);
+            if (owner == current) {
+                break;
+            }
+            current = owner;
+        }
+        return playerFound ? AffinityType.PLAYER : AffinityType.NONE;
     }
 
     private static void collectAffinityIds(@Nullable Entity entity, Set<UUID> ids, Set<UUID> visited, int depth) {
@@ -413,5 +435,11 @@ public final class MaidSpellAllyResolver {
     }
 
     private record MethodKey(Class<?> type, String name, @Nullable Class<?> returnType, @Nullable Class<?> parameterType) {
+    }
+
+    public enum AffinityType {
+        NONE,
+        PLAYER,
+        MAID
     }
 }

--- a/src/main/java/com/github/yimeng261/maidspell/compat/MaidSpellAllyResolver.java
+++ b/src/main/java/com/github/yimeng261/maidspell/compat/MaidSpellAllyResolver.java
@@ -1,6 +1,7 @@
 package com.github.yimeng261.maidspell.compat;
 
 import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.yimeng261.maidspell.compat.ftbteams.FTBTeamsCompat;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
@@ -61,7 +62,7 @@ public final class MaidSpellAllyResolver {
                 return true;
             }
         }
-        return false;
+        return FTBTeamsCompat.areFriendly(firstOwners, secondOwners);
     }
 
     private static boolean hasExplicitTeamAlliance(Entity first, Entity second) {

--- a/src/main/java/com/github/yimeng261/maidspell/compat/ftbteams/FTBTeamsCompat.java
+++ b/src/main/java/com/github/yimeng261/maidspell/compat/ftbteams/FTBTeamsCompat.java
@@ -1,0 +1,54 @@
+package com.github.yimeng261.maidspell.compat.ftbteams;
+
+import com.github.yimeng261.maidspell.compat.MaidSpellAllyResolver;
+import dev.ftb.mods.ftbteams.api.FTBTeamsAPI;
+import dev.ftb.mods.ftbteams.api.TeamManager;
+import net.minecraft.world.entity.Entity;
+import net.minecraftforge.fml.ModList;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+import java.util.UUID;
+
+public final class FTBTeamsCompat {
+    public static final String MOD_ID = "ftbteams";
+    private static final boolean LOADED = ModList.get().isLoaded(MOD_ID);
+
+    private FTBTeamsCompat() {
+    }
+
+    public static boolean isLoaded() {
+        return LOADED;
+    }
+
+    public static boolean areFriendly(@Nullable Entity first, @Nullable Entity second) {
+        if (!isLoaded() || first == null || second == null) {
+            return false;
+        }
+        return areFriendly(MaidSpellAllyResolver.collectAffinityIds(first), MaidSpellAllyResolver.collectAffinityIds(second));
+    }
+
+    public static boolean areFriendly(Set<UUID> firstIds, Set<UUID> secondIds) {
+        return isLoaded() && ApiBridge.areFriendly(firstIds, secondIds);
+    }
+
+    private static final class ApiBridge {
+
+        private static boolean areFriendly(Set<UUID> firstIds, Set<UUID> secondIds) {
+            FTBTeamsAPI.API api = FTBTeamsAPI.api();
+            if (api == null || !api.isManagerLoaded()) {
+                return false;
+            }
+
+            TeamManager manager = api.getManager();
+            for (UUID firstId : firstIds) {
+                for (UUID secondId : secondIds) {
+                    if (manager.arePlayersInSameTeam(firstId, secondId)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/github/yimeng261/maidspell/compat/ftbteams/FTBTeamsCompat.java
+++ b/src/main/java/com/github/yimeng261/maidspell/compat/ftbteams/FTBTeamsCompat.java
@@ -1,8 +1,13 @@
 package com.github.yimeng261.maidspell.compat.ftbteams;
 
+import com.github.yimeng261.maidspell.MaidSpellMod;
 import com.github.yimeng261.maidspell.compat.MaidSpellAllyResolver;
 import dev.ftb.mods.ftbteams.api.FTBTeamsAPI;
+import dev.ftb.mods.ftbteams.api.Team;
 import dev.ftb.mods.ftbteams.api.TeamManager;
+import dev.ftb.mods.ftbteams.api.event.TeamEvent;
+import dev.ftb.mods.ftbteams.api.property.BooleanProperty;
+import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.fml.ModList;
 
@@ -21,34 +26,71 @@ public final class FTBTeamsCompat {
         return LOADED;
     }
 
-    public static boolean areFriendly(@Nullable Entity first, @Nullable Entity second) {
-        if (!isLoaded() || first == null || second == null) {
-            return false;
+    public static void init() {
+        if (isLoaded()) {
+            ApiBridge.init();
         }
-        return areFriendly(MaidSpellAllyResolver.collectAffinityIds(first), MaidSpellAllyResolver.collectAffinityIds(second));
     }
 
-    public static boolean areFriendly(Set<UUID> firstIds, Set<UUID> secondIds) {
-        return isLoaded() && ApiBridge.areFriendly(firstIds, secondIds);
+    public static boolean areFriendly(@Nullable Entity source, @Nullable Entity target) {
+        if (!isLoaded() || source == null || target == null) {
+            return false;
+        }
+        return areFriendly(source, MaidSpellAllyResolver.collectAffinityIds(source),
+                MaidSpellAllyResolver.collectAffinityIds(target));
+    }
+
+    public static boolean areFriendly(Entity source, Set<UUID> sourceIds, Set<UUID> targetIds) {
+        if (!isLoaded()) {
+            return false;
+        }
+        MaidSpellAllyResolver.AffinityType sourceType = MaidSpellAllyResolver.getAffinityType(source);
+        return sourceType != MaidSpellAllyResolver.AffinityType.NONE
+                && ApiBridge.shouldPreventFriendlyFire(sourceIds, targetIds, sourceType);
     }
 
     private static final class ApiBridge {
+        private static final BooleanProperty ALLOW_PLAYER_FRIENDLY_FIRE = new BooleanProperty(
+                new ResourceLocation(MaidSpellMod.MOD_ID, "allow_player_friendly_fire"), true);
+        private static final BooleanProperty ALLOW_MAID_FRIENDLY_FIRE = new BooleanProperty(
+                new ResourceLocation(MaidSpellMod.MOD_ID, "allow_maid_friendly_fire"), false);
 
-        private static boolean areFriendly(Set<UUID> firstIds, Set<UUID> secondIds) {
+        private ApiBridge() {
+        }
+
+        private static void init() {
+            TeamEvent.COLLECT_PROPERTIES.register(event -> {
+                event.add(ALLOW_PLAYER_FRIENDLY_FIRE);
+                event.add(ALLOW_MAID_FRIENDLY_FIRE);
+            });
+        }
+
+        private static boolean shouldPreventFriendlyFire(Set<UUID> sourceIds, Set<UUID> targetIds,
+                                                         MaidSpellAllyResolver.AffinityType sourceType) {
             FTBTeamsAPI.API api = FTBTeamsAPI.api();
             if (api == null || !api.isManagerLoaded()) {
                 return false;
             }
 
             TeamManager manager = api.getManager();
-            for (UUID firstId : firstIds) {
-                for (UUID secondId : secondIds) {
-                    if (manager.arePlayersInSameTeam(firstId, secondId)) {
-                        return true;
+            for (UUID sourceId : sourceIds) {
+                for (UUID targetId : targetIds) {
+                    if (manager.arePlayersInSameTeam(sourceId, targetId)) {
+                        return manager.getTeamForPlayerID(sourceId)
+                                .map(team -> isFriendlyFireDisabled(team, sourceType))
+                                .orElse(false);
                     }
                 }
             }
             return false;
+        }
+
+        private static boolean isFriendlyFireDisabled(Team team, MaidSpellAllyResolver.AffinityType sourceType) {
+            return switch (sourceType) {
+                case PLAYER -> !team.getProperty(ALLOW_PLAYER_FRIENDLY_FIRE);
+                case MAID -> !team.getProperty(ALLOW_MAID_FRIENDLY_FIRE);
+                case NONE -> false;
+            };
         }
     }
 }

--- a/src/main/java/com/github/yimeng261/maidspell/compat/ftbteams/FTBTeamsCompat.java
+++ b/src/main/java/com/github/yimeng261/maidspell/compat/ftbteams/FTBTeamsCompat.java
@@ -8,6 +8,7 @@ import dev.ftb.mods.ftbteams.api.TeamManager;
 import dev.ftb.mods.ftbteams.api.event.TeamEvent;
 import dev.ftb.mods.ftbteams.api.property.BooleanProperty;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraftforge.fml.ModList;
 
@@ -49,6 +50,10 @@ public final class FTBTeamsCompat {
                 && ApiBridge.shouldPreventFriendlyFire(sourceIds, targetIds, sourceType);
     }
 
+    public static boolean canModifyTeamProperties(ServerPlayer player) {
+        return isLoaded() && ApiBridge.canModifyTeamProperties(player);
+    }
+
     private static final class ApiBridge {
         private static final BooleanProperty ALLOW_PLAYER_FRIENDLY_FIRE = new BooleanProperty(
                 new ResourceLocation(MaidSpellMod.MOD_ID, "allow_player_friendly_fire"), true);
@@ -83,6 +88,15 @@ public final class FTBTeamsCompat {
                 }
             }
             return false;
+        }
+
+        private static boolean canModifyTeamProperties(ServerPlayer player) {
+            FTBTeamsAPI.API api = FTBTeamsAPI.api();
+            return api != null
+                    && api.isManagerLoaded()
+                    && api.getManager().getTeamForPlayer(player)
+                    .map(team -> team.getRankForPlayer(player.getUUID()).isOfficerOrBetter())
+                    .orElse(false);
         }
 
         private static boolean isFriendlyFireDisabled(Team team, MaidSpellAllyResolver.AffinityType sourceType) {

--- a/src/main/java/com/github/yimeng261/maidspell/mixin/MaidSpellMixinPlugin.java
+++ b/src/main/java/com/github/yimeng261/maidspell/mixin/MaidSpellMixinPlugin.java
@@ -28,6 +28,8 @@ public class MaidSpellMixinPlugin implements IMixinConfigPlugin {
     private static final String ARS_MIXIN_PACKAGE = "com.github.yimeng261.maidspell.mixin.ars.";
     private static final String MNA_MOD_ID = "mna";
     private static final String MNA_MIXIN_PACKAGE = "com.github.yimeng261.maidspell.mixin.mna.";
+    private static final String FTB_TEAMS_MOD_ID = "ftbteams";
+    private static final String FTB_TEAMS_MIXIN_PACKAGE = "com.github.yimeng261.maidspell.mixin.ftbteams.";
 
     private boolean isIronsSpellbooksLoaded = false;
     private boolean isTlmMagicAnimationSupported = false;
@@ -36,6 +38,7 @@ public class MaidSpellMixinPlugin implements IMixinConfigPlugin {
     private boolean isPsiLoaded = false;
     private boolean isArsNouveauLoaded = false;
     private boolean isMnaLoaded = false;
+    private boolean isFtbTeamsLoaded = false;
 
     @Override
     public void onLoad(String mixinPackage) {
@@ -53,6 +56,7 @@ public class MaidSpellMixinPlugin implements IMixinConfigPlugin {
         isPsiLoaded = LoadingModList.get().getModFileById(PSI_MOD_ID) != null;
         isArsNouveauLoaded = LoadingModList.get().getModFileById(ARS_MOD_ID) != null;
         isMnaLoaded = LoadingModList.get().getModFileById(MNA_MOD_ID) != null;
+        isFtbTeamsLoaded = LoadingModList.get().getModFileById(FTB_TEAMS_MOD_ID) != null;
     }
 
     @Override
@@ -86,6 +90,10 @@ public class MaidSpellMixinPlugin implements IMixinConfigPlugin {
 
         if (mixinClassName.startsWith(MNA_MIXIN_PACKAGE)) {
             return isMnaLoaded;
+        }
+
+        if (mixinClassName.startsWith(FTB_TEAMS_MIXIN_PACKAGE)) {
+            return isFtbTeamsLoaded;
         }
 
         // 其他 Mixin 正常加载

--- a/src/main/java/com/github/yimeng261/maidspell/mixin/ftbteams/OpenGUIMixin.java
+++ b/src/main/java/com/github/yimeng261/maidspell/mixin/ftbteams/OpenGUIMixin.java
@@ -1,0 +1,42 @@
+package com.github.yimeng261.maidspell.mixin.ftbteams;
+
+import com.github.yimeng261.maidspell.MaidSpellMod;
+import com.github.yimeng261.maidspell.compat.ftbteams.FTBTeamsCompat;
+import dev.ftb.mods.ftbteams.api.property.TeamPropertyCollection;
+import dev.ftb.mods.ftbteams.data.TeamPropertyCollectionImpl;
+import dev.ftb.mods.ftbteams.net.OpenMyTeamGUIMessage;
+import net.minecraft.server.level.ServerPlayer;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = OpenMyTeamGUIMessage.class, remap = false)
+public abstract class OpenGUIMixin {
+    @Mutable
+    @Shadow
+    @Final
+    private TeamPropertyCollection properties;
+
+    @Inject(method =
+            "<init>(Lnet/minecraft/server/level/ServerPlayer;Ldev/ftb/mods/ftbteams/api/property/TeamPropertyCollection;)V",
+            at = @At("RETURN"),
+            remap = false
+    )
+    private void maidspell$hidePropertiesFromMembers(ServerPlayer player, TeamPropertyCollection properties, CallbackInfo callback) {
+        if (FTBTeamsCompat.canModifyTeamProperties(player)) {
+            return;
+        }
+
+        TeamPropertyCollectionImpl filteredProperties = new TeamPropertyCollectionImpl();
+        properties.forEach((property, value) -> {
+            if (!MaidSpellMod.MOD_ID.equals(property.getId().getNamespace())) {
+                filteredProperties.set(property, value.getValue());
+            }
+        });
+        this.properties = filteredProperties;
+    }
+}

--- a/src/main/java/com/github/yimeng261/maidspell/mixin/ftbteams/TamableAnimalMixin.java
+++ b/src/main/java/com/github/yimeng261/maidspell/mixin/ftbteams/TamableAnimalMixin.java
@@ -1,0 +1,20 @@
+package com.github.yimeng261.maidspell.mixin.ftbteams;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import com.github.yimeng261.maidspell.compat.ftbteams.FTBTeamsCompat;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.TamableAnimal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(TamableAnimal.class)
+public abstract class TamableAnimalMixin {
+    @Inject(method = "isAlliedTo(Lnet/minecraft/world/entity/Entity;)Z", at = @At("HEAD"), cancellable = true)
+    private void maidspell$checkFtbTeam(Entity entity, CallbackInfoReturnable<Boolean> callback) {
+        if ((Object) this instanceof EntityMaid maid && FTBTeamsCompat.areFriendly(maid, entity)) {
+            callback.setReturnValue(true);
+        }
+    }
+}

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -38,6 +38,13 @@ ordering = "NONE"
 side = "BOTH"
 
 [[dependencies."${mod_id}"]]
+modId = "ftbteams"
+mandatory = false
+versionRange = "[2001.3.2,)"
+ordering = "AFTER"
+side = "BOTH"
+
+[[dependencies."${mod_id}"]]
 modId = "ars_nouveau"
 mandatory = false
 versionRange = "[4.8.0,)"

--- a/src/main/resources/assets/touhou_little_maid_spell/lang/en_us.json
+++ b/src/main/resources/assets/touhou_little_maid_spell/lang/en_us.json
@@ -225,5 +225,10 @@
   "item.maidspell.yue_linglan.desc3": "Emits guiding dust towards the Elven Realm",
   "item.maidspell.jingxu_youlan.desc1": "An orchid of the pure ruins, cleansing all impurities",
   "item.maidspell.jingxu_youlan.desc2": "Periodically removes harmful effects from maids within 3 blocks",
-  "item.maidspell.jingxu_youlan.desc3": "Removes all potion effects from other living beings within 3 blocks"
+  "item.maidspell.jingxu_youlan.desc3": "Removes all potion effects from other living beings within 3 blocks",
+  "ftbteamsconfig.touhou_little_maid_spell": "Touhou Little Maid: Spell",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_player_friendly_fire": "Allow Player Friendly Fire",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_player_friendly_fire.tooltip": "Allows attacks caused by team players to affect teammates and their maids",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_maid_friendly_fire": "Allow Maid Friendly Fire",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_maid_friendly_fire.tooltip": "Allows attacks caused by team maids to affect teammates and their maids"
 }

--- a/src/main/resources/assets/touhou_little_maid_spell/lang/zh_cn.json
+++ b/src/main/resources/assets/touhou_little_maid_spell/lang/zh_cn.json
@@ -222,5 +222,10 @@
   "item.maidspell.yue_linglan.desc3": "散发指向精灵秘境的指引光尘",
   "item.maidspell.jingxu_youlan.desc1": "幽兰净墟，涤荡一切杂尘",
   "item.maidspell.jingxu_youlan.desc2": "每隔一段时间，移除周围3格内女仆的负面效果",
-  "item.maidspell.jingxu_youlan.desc3": "清除周围3格内其他生物的全部药水效果"
+  "item.maidspell.jingxu_youlan.desc3": "清除周围3格内其他生物的全部药水效果",
+  "ftbteamsconfig.touhou_little_maid_spell": "万法皆通",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_player_friendly_fire": "允许玩家友伤",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_player_friendly_fire.tooltip": "允许队伍玩家发起的攻击伤害队友及队友的女仆",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_maid_friendly_fire": "允许女仆友伤",
+  "ftbteamsconfig.touhou_little_maid_spell.allow_maid_friendly_fire.tooltip": "允许队伍女仆发起的攻击伤害队友及队友的女仆"
 }

--- a/src/main/resources/maidspell.mixins.json
+++ b/src/main/resources/maidspell.mixins.json
@@ -34,6 +34,7 @@
     "ars.SpellContextAccessor",
     "ars.SpellContextMixin",
     "mna.ChanneledSpellEntityMixin",
+    "ftbteams.TamableAnimalMixin",
     "iss.SyncedSpellDataMixin",
     "iss.UtilsMixin",
     "tlm.AbstractMaidContainerMixin",

--- a/src/main/resources/maidspell.mixins.json
+++ b/src/main/resources/maidspell.mixins.json
@@ -34,6 +34,7 @@
     "ars.SpellContextAccessor",
     "ars.SpellContextMixin",
     "mna.ChanneledSpellEntityMixin",
+    "ftbteams.OpenGUIMixin",
     "ftbteams.TamableAnimalMixin",
     "iss.SyncedSpellDataMixin",
     "iss.UtilsMixin",


### PR DESCRIPTION
避免TLM女仆在使用法术的时候伤害到存在同一个Teams里面的玩家以及玩家的女仆。

虽然可以通过原版指令/team来进行添加团队，但我觉得使用FTBTeams更方便。

且/team指令存在一个bug，玩家重新进入游戏之后需要重新让女仆和玩家加入同一个team里面才能避免误伤的情况。